### PR TITLE
chore: minor changes in `rejection.md`

### DIFF
--- a/organization/templates/rejection.md
+++ b/organization/templates/rejection.md
@@ -6,19 +6,19 @@ We received an overwhelming number of truly excellent applications (~NUMBER_OF_A
 
 Unfortunately, resources are limited and only NUMBER_OF_ACCEPTED_APPLICATIONS projects were accepted. Hard choices had to be made, and many good applications had to be rejected. The rejection is based on a number of criteria, many of which you could not influence, such as the number of mentors we had available and the number of slots Google gave us. You helped us a lot just by submitting such a good application. Your efforts certainly helped raise the bar, so thanks again.
 
-I hope that you learned something new. We'd love to have you continue to be a part of our community, and any contribution you make to stdlib is very much appreciated (bug reports, participating in community forums, patches, code, etc). But, of course, we understand that you may not have time, especially if you find some other job over the summer.
+We hope that you learned something new. We'd love to have you continue to be a part of our community, and any contribution you make to stdlib is very much appreciated (bug reports, participating in community forums, patches, code, etc). But, of course, we understand that you may not have time, especially if you find some other job over the summer.
 
-Nevertheless, thank you for discussing your proposal with us. If you decide to work on your project anyway, I am sure you'll find many users and people willing to help out. It's definitely something that we'd like to have in stdlib.
+Nevertheless, thank you for discussing your proposal with us. If you decide to work on your project anyway, we are sure you'll find many users and people willing to help out. It's definitely something that we'd like to have in stdlib.
 
-I encourage you to try again next year. Experience has shown that students who are involved in the project early are more likely to be accepted, so, if you do plan to do this, I recommend that you continue your contributions to the project.
+We encourage you to try again next year. Experience has shown that students who are involved in the project early are more likely to be accepted, so, if you do plan to do this, we recommend that you continue your contributions to the project.
 
 [IF PATCH MERGED]
 
-I also want to thank you for all the contributions that you made recently. It really helped improve stdlib, and now you are one of the authors of stdlib (i.e., your name is in the CONTRIBUTORS file that will ship with the download and in future releases). I certainly would be quite delighted if you decide to stay around.
+We also want to thank you for all the contributions that you made recently. It really helped improve stdlib, and now you are one of the authors of stdlib (i.e., your name is in the CONTRIBUTORS file that will ship with the download and in future releases). We certainly would be quite delighted if you decide to stay around.
 
 [IF PATCH UNMERGED]
 
-I also want to thank you for the patches that you submitted recently. These should really help improve stdlib. If you finish the work to get it merged, you will become one of the authors of stdlib (i.e., your name will be in the CONTRIBUTORS file that will ship with the download and in future releases). I certainly would be quite delighted if you decide to stay around.
+We also want to thank you for the patches that you submitted recently. These should really help improve stdlib. If you finish the work to get it merged, you will become one of the authors of stdlib (i.e., your name will be in the CONTRIBUTORS file that will ship with the download and in future releases). We certainly would be quite delighted if you decide to stay around.
 
 Thanks again and best of luck!
 


### PR DESCRIPTION
I am not sure if this template has to be used in collective sense, if yes, then `We` sounds better to me.