### PR TITLE
chore: add Snehil-Shah as a mentor

### DIFF
--- a/mentors.md
+++ b/mentors.md
@@ -64,6 +64,12 @@ If you are willing to mentor,
     -   GitHub: [gunjjoshi](https://github.com/gunjjoshi)
     -   projects: all
 
+- Snehil Shah
+
+    -   e-mail: [snehilshah.989@gmail.com](mailto:snehilshah.989@gmail.com)
+    -   GitHub: [Snehil-Shah](https://github.com/Snehil-Shah)
+    -   projects: most. Particularly around interactive computing, data visualization, project tooling, and developer tools/integrations.
+
 ## Time Commitment
 
 For primary mentors, we expect between a 3-10 hour a week commitment, where the requisite time decreases over the course of the program. Mentors can expect to spend more time the first few weeks prior to the contributor start date, where you'll be helping flesh out the project ideas, discussing projects with potential contributors, and selecting contributors based on their submitted proposals. Once contributors are selected and the program kicks off, your commitment should decrease to 2-4 hours a week and be comprised of a weekly 1 hour 1-on-1 where you'll establish rapport and discuss project progress and of some additional time to perform code review and answer questions as they arise. Ideally, a mentor will pair program with a contributor for 1 hour every two weeks throughout the duration of the program.


### PR DESCRIPTION
<!-- ----------^ Click "Preview"! -->

<!--

To prospective mentors:

If you are submitting a PR to be a GSoC mentor, please introduce yourself, provide a brief summary of your background, and tell us why you're interested in mentoring.

See <https://github.com/stdlib-js/google-summer-of-code/pull/29> for an example PR.

Thank you for your interest in being a GSoC mentor!

-->

I am Snehil Shah, a *not-so-regular* contributor at stdlib. I was a Google Summer of Code mentee in 2024 under stdlib (find that [here](https://summerofcode.withgoogle.com/archive/2024/projects/KRRdM6F8)), and since then have been working around pushing the interactive computing side of things ahead with my work on the REPL, and more recently on the Jupyter kernel.

I'm interested in being a mentor for GSoC because I like interacting, helping, and learning with new folks who are also interested in interacting, helping, and learning.
